### PR TITLE
Show the current error of the device as a Device property

### DIFF
--- a/aioaquarea/data.py
+++ b/aioaquarea/data.py
@@ -398,6 +398,11 @@ class Device(ABC):
         return len(self._status.fault_status) > 0
 
     @property
+    def current_error(self) -> FaultError | None:
+        """The current error of the device"""
+        return self._status.fault_status[0] if self.is_on_error else None
+
+    @property
     def operation_status(self) -> OperationStatus:
         """The operation status of the device"""
         return self._status.operation_status

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aioaquarea"
-version = "0.3.4"
+version = "0.3.5"
 authors = [
   { name="Carlos J. Aliaga", email="dev@cjaliaga.net" },
 ]


### PR DESCRIPTION
This error includes device errors such:

- Insufficient water flow

It doesn't include errors coming as part of API failures, such:
- Authentication errors
- Adapter disconnected