### PR TITLE
Allows getting statistics from Aquarea Client

### DIFF
--- a/aioaquarea/__init__.py
+++ b/aioaquarea/__init__.py
@@ -21,6 +21,7 @@ from .errors import (
     ClientError,
     RequestFailedError,
 )
+from .statistics import Consumption, DateType
 
 __all__: Tuple[str, ...] = (
     "Client",
@@ -37,4 +38,6 @@ __all__: Tuple[str, ...] = (
     "OperationStatus",
     "ExtendedOperationMode",
     "UpdateOperationMode",
+    "DateType",
+    "Consumption",
 )

--- a/aioaquarea/const.py
+++ b/aioaquarea/const.py
@@ -3,8 +3,11 @@
 AQUAREA_SERVICE_BASE = "https://aquarea-smart.panasonic.com/"
 AQUAREA_SERVICE_LOGIN = "remote/v1/api/auth/login"
 AQUAREA_SERVICE_DEVICES = "remote/v1/api/devices"
+AQUAREA_SERVICE_CONSUMPTION = "remote/v1/api/consumption"
 AQUAREA_SERVICE_CONTRACT = "remote/contract"
 
-AQUAREA_SERVICE_A2W_STATUS_DISPLAY = "https://aquarea-smart.panasonic.com/remote/a2wStatusDisplay"
+AQUAREA_SERVICE_A2W_STATUS_DISPLAY = (
+    "https://aquarea-smart.panasonic.com/remote/a2wStatusDisplay"
+)
 
 PANASONIC = "Panasonic"

--- a/aioaquarea/core.py
+++ b/aioaquarea/core.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 import functools
 import logging
 from typing import List, Optional
@@ -13,6 +13,7 @@ import aiohttp
 from .const import (
     AQUAREA_SERVICE_A2W_STATUS_DISPLAY,
     AQUAREA_SERVICE_BASE,
+    AQUAREA_SERVICE_CONSUMPTION,
     AQUAREA_SERVICE_CONTRACT,
     AQUAREA_SERVICE_DEVICES,
     AQUAREA_SERVICE_LOGIN,
@@ -34,6 +35,7 @@ from .data import (
     ZoneSensor,
 )
 from .errors import ApiError, AuthenticationError, AuthenticationErrorCodes, InvalidData
+from .statistics import Consumption, DateType
 
 
 def auth_required(fn):
@@ -508,6 +510,20 @@ class Client:
             content_type="application/json",
             json=data,
         )
+
+    @auth_required
+    async def get_device_consumption(
+        self, long_id: str, aggregation: DateType, date_input: str
+    ) -> Consumption:
+        """Get device consumption"""
+        response = await self.request(
+            "GET",
+            f"{AQUAREA_SERVICE_CONSUMPTION}/{long_id}?{aggregation}={date_input}",
+            referer=AQUAREA_SERVICE_A2W_STATUS_DISPLAY,
+        )
+
+        date_data = await response.json()
+        return Consumption(date_data.get("dateData")[0])
 
 
 class TankImpl(Tank):

--- a/aioaquarea/statistics.py
+++ b/aioaquarea/statistics.py
@@ -1,0 +1,59 @@
+"""Statistics models for Aquarea"""
+from __future__ import annotations
+from dataclasses import dataclass
+
+try:
+    from enum import StrEnum
+except ImportError:
+    from strenum import StrEnum
+
+
+class AggregationType(StrEnum):
+    """Aggregation type"""
+
+    HOURLY = "hourly"
+    DAILY = "daily"
+    MONTHLY = "monthly"
+
+
+class DataType(StrEnum):
+    """Data type"""
+
+    HEAT = "Heat"
+    COOL = "AC"
+    WATER_TANK = "HW"
+    TOTAL = "Consume"
+
+
+class DataSetName(StrEnum):
+    ENERGY = "energyShowing"
+    GENERATED = "generateEnergyShowing"
+    COST = "costShowing"
+    TEMPERATURE = "temperatureShowing"
+
+
+class Consumption:
+    @property
+    def energy(self) -> float:
+        """Energy consumption in kWh"""
+        raise NotImplementedError
+
+    @property
+    def generation(self) -> float:
+        """Energy generation in kWh"""
+        raise NotImplementedError
+
+    @property
+    def cost(self) -> float:
+        """Energy cost in configured currency"""
+        raise NotImplementedError
+
+    @property
+    def start_date(self) -> str:
+        """Start date of the period"""
+        raise NotImplementedError
+
+    @property
+    def aggregation(self) -> AggregationType:
+        """Aggregation type"""
+        raise NotImplementedError

--- a/aioaquarea/statistics.py
+++ b/aioaquarea/statistics.py
@@ -1,11 +1,21 @@
 """Statistics models for Aquarea"""
 from __future__ import annotations
+
 from dataclasses import dataclass
 
 try:
     from enum import StrEnum
 except ImportError:
     from strenum import StrEnum
+
+
+class DateType(StrEnum):
+    """Date types"""
+
+    DAY = "date"
+    WEEK = "week"
+    MONTH = "month"
+    YEAR = "year"
 
 
 class AggregationType(StrEnum):
@@ -25,7 +35,17 @@ class DataType(StrEnum):
     TOTAL = "Consume"
 
 
+class GenerationDataType(StrEnum):
+    """Generation data type"""
+
+    GHT = "GHT"
+    GHR = "GHR"
+    GHW = "GHW"
+
+
 class DataSetName(StrEnum):
+    """Data set name"""
+
     ENERGY = "energyShowing"
     GENERATED = "generateEnergyShowing"
     COST = "costShowing"
@@ -33,27 +53,47 @@ class DataSetName(StrEnum):
 
 
 class Consumption:
+    """Consumption"""
+
+    def __init__(self, date_data: dict[str, object]):
+        self._data = dict(
+            [
+                (
+                    dataset.get("name"),
+                    dict(
+                        [
+                            (data.get("name"), data.get("values"))
+                            for data in dataset.get("data", [])
+                        ]
+                    ),
+                )
+                for dataset in date_data.get("dataSets", [])
+            ]
+        )
+        self._start_date = date_data.get("startDate")
+        self._aggregation = AggregationType(date_data.get("timeline", {}).get("type"))
+
     @property
-    def energy(self) -> float:
+    def energy(self) -> dict[DataType, list[float | None]]:
         """Energy consumption in kWh"""
-        raise NotImplementedError
+        return self._data.get(DataSetName.ENERGY)
 
     @property
-    def generation(self) -> float:
+    def generation(self) -> dict[GenerationDataType, list[float]]:
         """Energy generation in kWh"""
-        raise NotImplementedError
+        return self._data.get(DataSetName.GENERATED)
 
     @property
-    def cost(self) -> float:
+    def cost(self) -> dict[DataType, list[float]]:
         """Energy cost in configured currency"""
-        raise NotImplementedError
+        return self._data.get(DataSetName.COST)
 
     @property
     def start_date(self) -> str:
         """Start date of the period"""
-        raise NotImplementedError
+        return self._start_date
 
     @property
     def aggregation(self) -> AggregationType:
         """Aggregation type"""
-        raise NotImplementedError
+        return self._aggregation


### PR DESCRIPTION
Adds support for getting statistics from the Aquarea API. A follow-up PR will include proper support into the Device and Tank implementations.

First part of #4 