### PR TITLE
Device can now get and refresh consumption data

### DIFF
--- a/aioaquarea/__init__.py
+++ b/aioaquarea/__init__.py
@@ -20,9 +20,10 @@ from .errors import (
     AuthenticationError,
     AuthenticationErrorCodes,
     ClientError,
+    DataNotAvailableError,
     RequestFailedError,
 )
-from .statistics import Consumption, DateType
+from .statistics import Consumption, ConsumptionType, DateType
 
 __all__: Tuple[str, ...] = (
     "Client",
@@ -39,7 +40,9 @@ __all__: Tuple[str, ...] = (
     "OperationStatus",
     "ExtendedOperationMode",
     "UpdateOperationMode",
-    "QuietMode"
+    "QuietMode",
     "DateType",
     "Consumption",
+    "ConsumptionType",
+    "DataNotAvailableError",
 )

--- a/aioaquarea/core.py
+++ b/aioaquarea/core.py
@@ -628,6 +628,7 @@ class DeviceImpl(Device):
                 and self._last_consumption_refresh is not None
                 and dt.datetime.now(self._timezone) - self._last_consumption_refresh
                 < self._consumption_refresh_interval
+                and None not in self._consumption.values()
             ):
                 return
 
@@ -702,7 +703,7 @@ class DeviceImpl(Device):
         await self._client.post_set_quiet_mode(self.long_id, mode)
 
     async def get_and_refresh_consumption(
-        self, date: datetime, consumption_type: DataType
+        self, date: dt.datetime, consumption_type: DataType
     ) -> float | None:
         """Retrieves consumption data and asyncronously refreshes if necessary for the specified date and type.
         :param date: The date to get the consumption for
@@ -717,7 +718,7 @@ class DeviceImpl(Device):
         return self._consumption[day].energy.get(consumption_type)[date.hour]
 
     def get_or_schedule_consumption(
-        self, date: datetime, consumption_type: DataType
+        self, date: dt.datetime, consumption_type: DataType
     ) -> float | None:
         """Gets available consumption data or schedules retrieval for the next refresh cycle.
         :param date: The date to get the consumption for

--- a/aioaquarea/core.py
+++ b/aioaquarea/core.py
@@ -42,7 +42,7 @@ from .errors import (
     DataNotAvailableError,
     InvalidData,
 )
-from .statistics import Consumption, DataType, DateType
+from .statistics import Consumption, ConsumptionType, DateType
 
 
 def auth_required(fn):
@@ -529,14 +529,7 @@ class Client:
     @auth_required
     async def post_set_quiet_mode(self, long_id: str, mode: QuietMode) -> None:
         """Post quiet mode"""
-        data = {
-            "status": [
-                {
-                    "deviceGuid": long_id,
-                    "quietMode": mode.value
-                }
-            ]
-        }
+        data = {"status": [{"deviceGuid": long_id, "quietMode": mode.value}]}
 
         response = await self.request(
             "POST",
@@ -703,7 +696,7 @@ class DeviceImpl(Device):
         await self._client.post_set_quiet_mode(self.long_id, mode)
 
     async def get_and_refresh_consumption(
-        self, date: dt.datetime, consumption_type: DataType
+        self, date: dt.datetime, consumption_type: ConsumptionType
     ) -> float | None:
         """Retrieves consumption data and asyncronously refreshes if necessary for the specified date and type.
         :param date: The date to get the consumption for
@@ -718,7 +711,7 @@ class DeviceImpl(Device):
         return self._consumption[day].energy.get(consumption_type)[date.hour]
 
     def get_or_schedule_consumption(
-        self, date: dt.datetime, consumption_type: DataType
+        self, date: dt.datetime, consumption_type: ConsumptionType
     ) -> float | None:
         """Gets available consumption data or schedules retrieval for the next refresh cycle.
         :param date: The date to get the consumption for

--- a/aioaquarea/data.py
+++ b/aioaquarea/data.py
@@ -535,11 +535,17 @@ class Device(ABC):
         """
 
     @abstractmethod
-    async def get_consumption(self, date: datetime, consumption_type: DataType, force_retrieval: bool = False) ->  float | None:
-        """Gets the consumption for the given date and type
+    async def get_and_refresh_consumption(self, date: datetime, consumption_type: DataType) ->  float | None:
+        """Retrieves consumption data and asyncronously refreshes if necessary for the specified date and type.
         :param date: The date to get the consumption for
-        :param consumption_type: The consumption type to get
-        :param force_retrieval: If true, the consumption will be retrieved from the Aquarea API. If false, it will be retrieved on the next refresh"""
+        :param consumption_type: The consumption type to get"""
+
+
+   @abstractmethod
+    def get_or_schedule_consumption(self, date: datetime, consumption_type: DataType) ->  float | None:
+        """Gets available consumption data or schedules retrieval for the next refresh cycle.
+        :param date: The date to get the consumption for
+        :param consumption_type: The consumption type to get"""
 
 class LimitedSizeDict(OrderedDict):
     def __init__(self, max_keys: int, *args, **kwds):

--- a/aioaquarea/errors.py
+++ b/aioaquarea/errors.py
@@ -58,3 +58,6 @@ class AuthenticationErrorCodes(StrEnum):
     SESSION_CLOSED = "1001-0001"
     INVALID_USERNAME_OR_PASSWORD = "1001-1401"
     INVALID_CREDENTIALS = "1000-1401"
+
+class DataNotAvailableError(Exception):
+    """Exception raised when data is not available"""

--- a/aioaquarea/statistics.py
+++ b/aioaquarea/statistics.py
@@ -1,8 +1,6 @@
 """Statistics models for Aquarea"""
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 try:
     from enum import StrEnum
 except ImportError:
@@ -26,7 +24,7 @@ class AggregationType(StrEnum):
     MONTHLY = "monthly"
 
 
-class DataType(StrEnum):
+class ConsumptionType(StrEnum):
     """Data type"""
 
     HEAT = "Heat"
@@ -74,7 +72,7 @@ class Consumption:
         self._aggregation = AggregationType(date_data.get("timeline", {}).get("type"))
 
     @property
-    def energy(self) -> dict[DataType, list[float | None]]:
+    def energy(self) -> dict[ConsumptionType, list[float | None]]:
         """Energy consumption in kWh"""
         return self._data.get(DataSetName.ENERGY)
 
@@ -84,7 +82,7 @@ class Consumption:
         return self._data.get(DataSetName.GENERATED)
 
     @property
-    def cost(self) -> dict[DataType, list[float]]:
+    def cost(self) -> dict[ConsumptionType, list[float]]:
         """Energy cost in configured currency"""
         return self._data.get(DataSetName.COST)
 

--- a/aioaquarea/util.py
+++ b/aioaquarea/util.py
@@ -1,0 +1,17 @@
+from collections import OrderedDict
+
+
+class LimitedSizeDict(OrderedDict):
+    def __init__(self, max_keys: int, *args, **kwds):
+        self.size_limit = max_keys
+        OrderedDict.__init__(self, *args, **kwds)
+        self._check_size_limit()
+
+    def __setitem__(self, key, value):
+        OrderedDict.__setitem__(self, key, value)
+        self._check_size_limit()
+
+    def _check_size_limit(self):
+        if self.size_limit is not None:
+            while len(self) > self.size_limit:
+                self.popitem(last=False)


### PR DESCRIPTION
The device object can get and refresh consumption data. Since the consumption data is not refreshed so often, it can be configured with a `timedelta` to avoid exhausting the Aquarea API with useless calls.

Designed to support https://github.com/cjaliaga/home-assistant-aquarea/issues/1

Completes #23.
 