### PR TITLE
Refactor DeviceStatus class to remove kw_only parameter

### DIFF
--- a/aioaquarea/data.py
+++ b/aioaquarea/data.py
@@ -188,7 +188,7 @@ class DeviceInfo:
     zones: list[DeviceZoneInfo]
 
 
-@dataclass(kw_only=True)
+@dataclass()
 class DeviceStatus:
     """Device status"""
 


### PR DESCRIPTION
Fixing support for Python 3.9 for the time being.

Closes #39 