### PR TITLE
Fix token expiration check

### DIFF
--- a/aioaquarea/core.py
+++ b/aioaquarea/core.py
@@ -177,6 +177,10 @@ class Client:
         if not self._access_token:
             return False
 
+        # We don't have an expiration time, so we assume the token is valid
+        if not self._token_expiration:
+            return True
+        
         now = dt.datetime.now(tz=dt.timezone.utc)
         return now < self._token_expiration
 


### PR DESCRIPTION
This pull request includes a change to the `is_logged` method in the `aioaquarea/core.py` file. The change adds a condition to handle cases where there is no token expiration time, in which case the method assumes the token is valid.

In more detail:

* [`aioaquarea/core.py`](diffhunk://#diff-5883f25655e2bd39badfd28e6684033232ec465eb4cc2d7be2dacc04cb120b0dR180-R183): In the `is_logged` method, added a condition to handle cases where `_token_expiration` is `None`. In such cases, the method now returns `True`, assuming that the token is valid.