### PR TITLE
Add batch update context manager for grouped device operations (#8)

### DIFF
--- a/aioaquarea/__init__.py
+++ b/aioaquarea/__init__.py
@@ -18,6 +18,7 @@ from .data import (
     ForceHeater,
     HolidayTimer,
     OperationStatus,
+    PendingDeviceUpdates,
     PowerfulTime,
     PumpDuty,
     QuietMode,
@@ -64,4 +65,5 @@ __all__: Tuple[str, ...] = (
     "PowerfulTime",
     "AquareaEnvironment",
     "SpecialStatus",
+    "PendingDeviceUpdates",
 )

--- a/aioaquarea/core.py
+++ b/aioaquarea/core.py
@@ -22,6 +22,7 @@ from .data import (
     ForceHeater,
     HolidayTimer,
     OperationStatus,
+    PendingDeviceUpdates,
     PowerfulTime,
     QuietMode,
     SpecialStatus,
@@ -366,6 +367,16 @@ class AquareaClient:  # Renamed Client to AquareaClient
         return await self._device_control.post_device_set_powerful_time(
             long_id, powerful_time
         )
+
+    async def _post_device_batch_update(
+        self, long_id: str, updates: PendingDeviceUpdates
+    ) -> None:
+        """Post a batch of device updates in a single API call.
+
+        :param long_id: The device GUID
+        :param updates: The pending updates to apply
+        """
+        await self._device_control.post_device_batch_update(long_id, updates)
 
     async def get_device_consumption(
         self, long_id: str, aggregation: DateType, date_input: str

--- a/aioaquarea/data.py
+++ b/aioaquarea/data.py
@@ -354,6 +354,44 @@ class DeviceOperationStatusUpdate:
     operationStatus: OperationStatus
 
 
+@dataclass
+class PendingDeviceUpdates:
+    """Collects pending device updates for batch operations"""
+
+    operation_mode: UpdateOperationMode | None = None
+    operation_status: OperationStatus | None = None
+    zone_updates: dict[int, OperationStatus] | None = None
+    zone_temperature_updates: list[ZoneTemperatureSetUpdate] | None = None
+    tank_operation_status: OperationStatus | None = None
+    tank_temperature: int | None = None
+    quiet_mode: QuietMode | None = None
+    force_dhw: ForceDHW | None = None
+    force_heater: ForceHeater | None = None
+    holiday_timer: HolidayTimer | None = None
+    powerful_time: PowerfulTime | None = None
+    request_defrost: bool = False
+
+    @property
+    def has_pending(self) -> bool:
+        """True if there are any pending updates"""
+        return any(
+            v is not None and v is not False
+            for v in (
+                self.operation_mode,
+                self.operation_status,
+                self.zone_updates,
+                self.zone_temperature_updates,
+                self.tank_operation_status,
+                self.tank_temperature,
+                self.quiet_mode,
+                self.force_dhw,
+                self.force_heater,
+                self.holiday_timer,
+                self.powerful_time,
+            )
+        ) or self.request_defrost
+
+
 class DeviceZone:
     """Device zone"""
 
@@ -870,4 +908,17 @@ class Device(ABC):
         """Set the powerful time.
 
         :param powerful_time: Time to enable powerful mode
+        """
+
+    @abstractmethod
+    def batch_update(self) -> "DeviceUpdateBatch":
+        """Create a context manager for batch updates.
+
+        All changes made within the context will be sent together
+        in a single API call when the context exits.
+
+        Usage:
+            async with device.batch_update():
+                await device.set_mode(UpdateOperationMode.HEAT)
+                await device.set_quiet_mode(QuietMode.LEVEL1)
         """

--- a/aioaquarea/device_control.py
+++ b/aioaquarea/device_control.py
@@ -10,6 +10,7 @@ from .data import (
     ForceHeater,
     HolidayTimer,
     OperationStatus,
+    PendingDeviceUpdates,
     PowerfulTime,
     QuietMode,
     SpecialStatus,
@@ -319,6 +320,82 @@ class AquareaDeviceControl:
             "apiName": "/remote/v1/api/devices",
             "requestMethod": "POST",
             "bodyParam": {"gwid": long_id, "powerfulRequest": powerful_time.value},
+        }
+
+        await self._api_client.request(
+            "POST",
+            "remote/v1/app/common/transfer",
+            json=data,
+            throw_on_error=True,
+        )
+
+    async def post_device_batch_update(
+        self, long_id: str, updates: PendingDeviceUpdates
+    ) -> None:
+        """Post a batch of device updates in a single API call.
+
+        Merges all pending changes into one transfer API request.
+        :param long_id: The device GUID
+        :param updates: The pending updates to apply
+        """
+        body_param: dict = {"gwid": long_id}
+
+        if updates.operation_mode is not None:
+            body_param["operationMode"] = updates.operation_mode.value
+
+        if updates.operation_status is not None:
+            body_param["operationStatus"] = updates.operation_status.value
+
+        if updates.zone_updates is not None:
+            body_param["zoneStatus"] = [
+                {"zoneId": zid, "operationStatus": op.value}
+                for zid, op in updates.zone_updates.items()
+            ]
+
+        if updates.zone_temperature_updates is not None:
+            zone_status = body_param.get("zoneStatus", [])
+            existing_zones = {z["zoneId"]: z for z in zone_status}
+            for temp_update in updates.zone_temperature_updates:
+                if temp_update.zone_id in existing_zones:
+                    if temp_update.heat_set is not None:
+                        existing_zones[temp_update.zone_id]["heatSet"] = temp_update.heat_set
+                    if temp_update.cool_set is not None:
+                        existing_zones[temp_update.zone_id]["coolSet"] = temp_update.cool_set
+                else:
+                    entry = {"zoneId": temp_update.zone_id}
+                    if temp_update.heat_set is not None:
+                        entry["heatSet"] = temp_update.heat_set
+                    if temp_update.cool_set is not None:
+                        entry["coolSet"] = temp_update.cool_set
+                    zone_status.append(entry)
+            if not body_param.get("zoneStatus"):
+                body_param["zoneStatus"] = zone_status
+
+        tank_status: dict = {}
+        if updates.tank_operation_status is not None:
+            tank_status["operationStatus"] = updates.tank_operation_status.value
+        if updates.tank_temperature is not None:
+            tank_status["heatSet"] = updates.tank_temperature
+        if tank_status:
+            body_param["tankStatus"] = tank_status
+
+        if updates.quiet_mode is not None:
+            body_param["quietMode"] = updates.quiet_mode.value
+        if updates.force_dhw is not None:
+            body_param["forceDHW"] = updates.force_dhw.value
+        if updates.force_heater is not None:
+            body_param["forceHeater"] = updates.force_heater.value
+        if updates.holiday_timer is not None:
+            body_param["holidayTimer"] = updates.holiday_timer.value
+        if updates.powerful_time is not None:
+            body_param["powerfulRequest"] = updates.powerful_time.value
+        if updates.request_defrost:
+            body_param["forcedefrost"] = 1
+
+        data = {
+            "apiName": "/remote/v1/api/devices",
+            "requestMethod": "POST",
+            "bodyParam": body_param,
         }
 
         await self._api_client.request(

--- a/aioaquarea/entities.py
+++ b/aioaquarea/entities.py
@@ -15,6 +15,7 @@ from .data import (
     HolidayTimer,
     OperationMode,
     OperationStatus,
+    PendingDeviceUpdates,
     PowerfulTime,
     QuietMode,
     SpecialStatus,
@@ -92,7 +93,9 @@ class DeviceImpl(Device):
         self._consumption_refresh_interval = consumption_refresh_interval
         self._consumption: dict[
             dt.date, Consumption
-        ] = {}  # Initialize _consumption with dt.date as key and single Consumption object for the day
+        ] = {}
+        self._batching: bool = False
+        self._pending_updates: PendingDeviceUpdates | None = None
 
         if self.has_tank and self._status.tank_status:
             self._tank = TankImpl(self._status.tank_status[0], self, self._client)
@@ -193,7 +196,10 @@ class DeviceImpl(Device):
             self._consumption_refresh_lock.release()
 
     async def __set_operation_status__(self, status: OperationStatus) -> None:
-        await self._client.post_device_operation_status(self.long_id, status)
+        if self._batching and self._pending_updates:
+            self._pending_updates.operation_status = status
+        else:
+            await self._client.post_device_operation_status(self.long_id, status)
 
     async def set_mode(
         self, mode: UpdateOperationMode, zone_id: int | None = None
@@ -243,14 +249,20 @@ class DeviceImpl(Device):
                     )
                 )
 
-        await self._client.post_device_operation_update(
-            self.long_id,
-            mode,
-            zones,
-            operation_status,
-            tank_operation_status,
-            zone_temperature_updates,
-        )
+        if self._batching and self._pending_updates:
+            self._pending_updates.operation_mode = mode
+            self._pending_updates.zone_updates = zones
+            self._pending_updates.tank_operation_status = tank_operation_status
+            self._pending_updates.zone_temperature_updates = zone_temperature_updates
+        else:
+            await self._client.post_device_operation_update(
+                self.long_id,
+                mode,
+                zones,
+                operation_status,
+                tank_operation_status,
+                zone_temperature_updates,
+            )
 
     async def set_temperature(
         self, temperature: int, zone_id: int | None = None
@@ -268,23 +280,38 @@ class DeviceImpl(Device):
             _LOGGER.warning("Zone does not support setting temperature.")
             return
 
-        if self.mode in [ExtendedOperationMode.AUTO_COOL, ExtendedOperationMode.COOL]:
-            _LOGGER.info(
-                f"Setting cool temperature for zone {zone_id} to {temperature}"
-            )
+        zone_update = ZoneTemperatureSetUpdate(
+            zone_id=zone_id,
+            heat_set=(
+                temperature
+                if self.mode in (ExtendedOperationMode.AUTO_HEAT, ExtendedOperationMode.HEAT)
+                else None
+            ),
+            cool_set=(
+                temperature
+                if self.mode in (ExtendedOperationMode.AUTO_COOL, ExtendedOperationMode.COOL)
+                else None
+            ),
+        )
+
+        if self._batching and self._pending_updates:
+            if self._pending_updates.zone_temperature_updates is None:
+                self._pending_updates.zone_temperature_updates = []
+            self._pending_updates.zone_temperature_updates.append(zone_update)
+        elif self.mode in [ExtendedOperationMode.AUTO_COOL, ExtendedOperationMode.COOL]:
             await self._client.post_device_zone_cool_temperature(
                 self.long_id, zone_id, temperature
             )
         elif self.mode in [ExtendedOperationMode.AUTO_HEAT, ExtendedOperationMode.HEAT]:
-            _LOGGER.info(
-                f"Setting heat temperature for zone {zone_id} to {temperature}"
-            )
             await self._client.post_device_zone_heat_temperature(
                 self.long_id, zone_id, temperature
             )
 
     async def set_quiet_mode(self, mode: QuietMode) -> None:
-        await self._client.post_device_set_quiet_mode(self.long_id, mode)
+        if self._batching and self._pending_updates:
+            self._pending_updates.quiet_mode = mode
+        else:
+            await self._client.post_device_set_quiet_mode(self.long_id, mode)
 
     async def get_and_refresh_consumption(
         self, date: dt.datetime, consumption_type: ConsumptionType
@@ -343,7 +370,10 @@ class DeviceImpl(Device):
 
         :param force_dhw: Set the Force DHW mode if the device has a tank.
         """
-        await self._client.post_device_force_dhw(self.long_id, force_dhw)
+        if self._batching and self._pending_updates:
+            self._pending_updates.force_dhw = force_dhw
+        else:
+            await self._client.post_device_force_dhw(self.long_id, force_dhw)
 
     async def set_force_heater(self, force_heater: ForceHeater) -> None:
         """Set the force heater configuration.
@@ -351,12 +381,18 @@ class DeviceImpl(Device):
         :param force_heater: The force heater mode.
         """
         if self.force_heater is not force_heater:
-            await self._client.post_device_force_heater(self.long_id, force_heater)
+            if self._batching and self._pending_updates:
+                self._pending_updates.force_heater = force_heater
+            else:
+                await self._client.post_device_force_heater(self.long_id, force_heater)
 
     async def request_defrost(self) -> None:
         """Request defrost."""
         if self.device_mode_status is not DeviceModeStatus.DEFROST:
-            await self._client.post_device_request_defrost(self.long_id)
+            if self._batching and self._pending_updates:
+                self._pending_updates.request_defrost = True
+            else:
+                await self._client.post_device_request_defrost(self.long_id)
 
     async def set_holiday_timer(self, holiday_timer: HolidayTimer) -> None:
         """Enable or disable the holiday timer mode.
@@ -364,7 +400,10 @@ class DeviceImpl(Device):
         :param holiday_timer: The holiday timer option
         """
         if self.holiday_timer is not holiday_timer:
-            await self._client.post_device_holiday_timer(self.long_id, holiday_timer)
+            if self._batching and self._pending_updates:
+                self._pending_updates.holiday_timer = holiday_timer
+            else:
+                await self._client.post_device_holiday_timer(self.long_id, holiday_timer)
 
     async def set_powerful_time(self, powerful_time: PowerfulTime) -> None:
         """Set the powerful time.
@@ -372,9 +411,12 @@ class DeviceImpl(Device):
         :param powerful_time: Time to enable powerful mode
         """
         if self.powerful_time is not powerful_time:
-            await self._client.post_device_set_powerful_time(
-                self.long_id, powerful_time
-            )
+            if self._batching and self._pending_updates:
+                self._pending_updates.powerful_time = powerful_time
+            else:
+                await self._client.post_device_set_powerful_time(
+                    self.long_id, powerful_time
+                )
 
     async def __set_special_status__(
         self,
@@ -388,3 +430,34 @@ class DeviceImpl(Device):
         await self._client.post_device_set_special_status(
             self.long_id, special_status, zones
         )
+
+    def batch_update(self) -> "DeviceUpdateBatch":
+        """Create a context manager for batch updates.
+
+        Usage:
+            async with device.batch_update():
+                await device.set_mode(UpdateOperationMode.HEAT)
+                await device.set_quiet_mode(QuietMode.LEVEL1)
+        """
+        return DeviceUpdateBatch(self)
+
+
+class DeviceUpdateBatch:
+    """Context manager for batching multiple device updates into one API call."""
+
+    def __init__(self, device: DeviceImpl) -> None:
+        self._device = device
+
+    async def __aenter__(self) -> "DeviceUpdateBatch":
+        self._device._batching = True
+        self._device._pending_updates = PendingDeviceUpdates()
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        self._device._batching = False
+        updates = self._device._pending_updates
+        self._device._pending_updates = None
+        if updates and updates.has_pending:
+            await self._device._client._post_device_batch_update(
+                self._device.long_id, updates
+            )


### PR DESCRIPTION
Introduces a context manager for grouping multiple device updates into a single API call, reducing network round trips.

**New types:**
- `PendingDeviceUpdates` dataclass — collects all mutable device fields
- `DeviceUpdateBatch` async context manager — queues changes, commits on exit

**New method on Device:**
- `batch_update()` returns a context manager

**Usage:**
```python
async with device.batch_update():
    await device.set_mode(UpdateOperationMode.HEAT)
    await device.set_quiet_mode(QuietMode.LEVEL1)
    await device.set_force_dhw(ForceDHW.ON)
# All three changes sent in a single transfer API call
```

All setter methods (`set_mode`, `set_temperature`, `set_quiet_mode`, `set_force_dhw`, `set_force_heater`, `set_holiday_timer`, `set_powerful_time`, `request_defrost`, `turn_on`, `turn_off\)) check for active batch context and queue changes instead of making immediate API calls.

Closes #8