### PR TITLE
Fix energy consumption stats NaN/Inf/zero handling (#25)

### DIFF
--- a/aioaquarea/statistics.py
+++ b/aioaquarea/statistics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 try:
     from enum import StrEnum
 except ImportError:
@@ -34,19 +36,36 @@ class ConsumptionType(StrEnum):
     TOTAL = "Consume"
 
 
+def _sanitize_float(value: object) -> float | None:
+    """Convert a value to float, handling NaN, None, and invalid values.
+
+    :param value: The raw value from the API
+    :return: float value or None if invalid
+    """
+    if value is None:
+        return None
+    try:
+        result = float(value)
+        if math.isnan(result) or math.isinf(result):
+            return None
+        return result
+    except (ValueError, TypeError):
+        return None
+
+
 class Consumption:
     """Consumption"""
 
     def __init__(self, data: dict[str, object]):
         self._data = data
-        self._heat_consumption = data.get("heatConsumption")
-        self._cool_consumption = data.get("coolConsumption")
-        self._tank_consumption = data.get("tankConsumption")
-        self._heat_cost = data.get("heatCost")
-        self._cool_cost = data.get("coolCost")
-        self._tank_cost = data.get("tankCost")
+        self._heat_consumption = _sanitize_float(data.get("heatConsumption"))
+        self._cool_consumption = _sanitize_float(data.get("coolConsumption"))
+        self._tank_consumption = _sanitize_float(data.get("tankConsumption"))
+        self._heat_cost = _sanitize_float(data.get("heatCost"))
+        self._cool_cost = _sanitize_float(data.get("coolCost"))
+        self._tank_cost = _sanitize_float(data.get("tankCost"))
         self._data_time = data.get("dataTime")
-        self._outdoor_temp = data.get("outdoorTemp")
+        self._outdoor_temp = _sanitize_float(data.get("outdoorTemp"))
 
     @property
     def heat_consumption(self) -> float | None:
@@ -90,15 +109,19 @@ class Consumption:
 
     @property
     def total_consumption(self) -> float | None:
-        """Total consumption in kWh (sum of heat, cool, and tank consumption)"""
-        total = 0.0
-        if self._heat_consumption is not None:
-            total += self._heat_consumption
-        if self._cool_consumption is not None:
-            total += self._cool_consumption
-        if self._tank_consumption is not None:
-            total += self._tank_consumption
-        return total if total > 0 else None
+        """Total consumption in kWh (sum of heat, cool, and tank consumption).
+
+        Returns None only if all components are None (no data available).
+        Returns 0 if all components are 0 (valid reading of zero consumption).
+        """
+        components = [
+            self._heat_consumption,
+            self._cool_consumption,
+            self._tank_consumption,
+        ]
+        if all(c is None for c in components):
+            return None
+        return sum(c for c in components if c is not None)
 
     @property
     def raw_data(self) -> dict[str, object]:

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,0 +1,103 @@
+"""Tests for aioaquarea statistics models."""
+
+import math
+
+from aioaquarea.statistics import Consumption, DateType, ConsumptionType
+
+
+class TestConsumption:
+    def test_valid_data(self):
+        c = Consumption({
+            "heatConsumption": 15.5,
+            "coolConsumption": 5.2,
+            "tankConsumption": 3.1,
+            "heatCost": 2.50,
+            "coolCost": 0.80,
+            "tankCost": 0.50,
+            "dataTime": "20240101",
+            "outdoorTemp": 12.0,
+        })
+        assert c.heat_consumption == 15.5
+        assert c.cool_consumption == 5.2
+        assert c.tank_consumption == 3.1
+        assert c.total_consumption == 23.8
+        assert c.heat_cost == 2.50
+        assert c.cool_cost == 0.80
+        assert c.tank_cost == 0.50
+        assert c.data_time == "20240101"
+        assert c.outdoor_temp == 12.0
+
+    def test_nan_values(self):
+        c = Consumption({
+            "heatConsumption": float("nan"),
+            "coolConsumption": "NaN",
+            "tankConsumption": None,
+        })
+        assert c.heat_consumption is None
+        assert c.cool_consumption is None
+        assert c.tank_consumption is None
+        assert c.total_consumption is None
+
+    def test_inf_values(self):
+        c = Consumption({
+            "heatConsumption": float("inf"),
+            "coolConsumption": float("-inf"),
+        })
+        assert c.heat_consumption is None
+        assert c.cool_consumption is None
+
+    def test_all_zeros(self):
+        c = Consumption({
+            "heatConsumption": 0,
+            "coolConsumption": 0,
+            "tankConsumption": 0,
+        })
+        assert c.total_consumption == 0
+
+    def test_partial_data(self):
+        c = Consumption({"heatConsumption": 8.0})
+        assert c.heat_consumption == 8.0
+        assert c.cool_consumption is None
+        assert c.tank_consumption is None
+        assert c.total_consumption == 8.0
+
+    def test_empty_data(self):
+        c = Consumption({})
+        assert c.heat_consumption is None
+        assert c.total_consumption is None
+        assert c.data_time is None
+
+    def test_invalid_types(self):
+        c = Consumption({
+            "heatConsumption": "invalid",
+            "coolConsumption": [],
+        })
+        assert c.heat_consumption is None
+        assert c.cool_consumption is None
+
+    def test_string_numbers(self):
+        c = Consumption({
+            "heatConsumption": "10.5",
+            "outdoorTemp": "25.0",
+        })
+        assert c.heat_consumption == 10.5
+        assert c.outdoor_temp == 25.0
+
+    def test_raw_data(self):
+        raw = {"heatConsumption": 10}
+        c = Consumption(raw)
+        assert c.raw_data is raw
+
+
+class TestEnums:
+    def test_date_type(self):
+        assert DateType.DAY == "date"
+        assert DateType.WEEK == "week"
+        assert DateType.MONTH == "month"
+        assert DateType.YEAR == "year"
+
+    def test_consumption_type(self):
+        assert ConsumptionType.HEAT == "Heat"
+        assert ConsumptionType.COOL == "AC"
+        assert ConsumptionType.WATER_TANK == "HW"
+        assert ConsumptionType.TOTAL == "Consume"


### PR DESCRIPTION
Fixes the Consumption class to handle problematic API response values:

- **NaN values**: , string  now converted to 
- **Inf values**:  /  now converted to 
- **Zero total**:  now returns  when all components are zero (previously returned )
- **String numbers**: values like  now correctly parsed to 
- **Invalid types**: non-numeric values return  instead of crashing

Closes #25