### PR TITLE
Fix NoneType error in set_hvac_mode and operation_status parsing (#55)

### DIFF
--- a/aioaquarea/device_manager.py
+++ b/aioaquarea/device_manager.py
@@ -195,9 +195,12 @@ class DeviceManager:
         device = json_response.get("status")
         operation_mode_value = device.get("operationMode")
 
+        raw_operation_status = device.get("operationStatus")
+        if raw_operation_status is None:
+            raw_operation_status = device.get("specialStatus", 0)
         device_status = DeviceStatus(
             long_id=device_info.device_id,  # Use device_info.long_id here
-            operation_status=OperationStatus(device.get("specialStatus")),
+            operation_status=OperationStatus(raw_operation_status),
             device_status=DeviceModeStatus(device.get("deiceStatus")),
             temperature_outdoor=device.get("outdoorNow"),
             operation_mode=(

--- a/aioaquarea/entities.py
+++ b/aioaquarea/entities.py
@@ -212,8 +212,8 @@ class DeviceImpl(Device):
 
         tank_off = (
             not self.has_tank
-            or self.has_tank
-            and self.tank.operation_status == OperationStatus.OFF
+            or self.tank is None
+            or self.tank.operation_status == OperationStatus.OFF
         )
 
         operation_status = (
@@ -226,7 +226,7 @@ class DeviceImpl(Device):
 
         tank_operation_status = (
             self.tank.operation_status
-            if self.has_tank and self.tank
+            if self.has_tank and self.tank is not None
             else OperationStatus.OFF
         )
 


### PR DESCRIPTION
Fixes two bugs causing 'NoneType' object has no attribute 'operation_status':

1. **device_manager.py**:  was mapped from  API field instead of . Now tries  first, falls back to .

2. **entities.py**:  calculation accessed  without None guard, crashing when a device has tank flag True but no tank data available.

Closes #55