### PR TITLE
Add hacs.json and clarify HACS setup in README (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This library requires:
 - aiohttp
 
 ## Usage
-The library supports the production environment of the Panasonic Aquarea Smart Cloud API and also the Demo environment. One of the main usages of this library is to integrate the Panasonic Aquarea Smart Cloud API with Home Assistant via [home-assistant-aquarea](https://github.com/cjaliaga/home-assistant-aquarea)
+The library supports the production environment of the Panasonic Aquarea Smart Cloud API and also the Demo environment. One of the main usages of this library is to integrate the Panasonic Aquarea Smart Cloud API with Home Assistant via [home-assistant-aquarea](https://github.com/cjaliaga/home-assistant-aquarea). This repo is a Python library, not a HACS custom component — to install the HA integration, add `https://github.com/cjaliaga/home-assistant-aquarea` to HACS instead.
 
 Here is a simple example of how to use the library via getting a device object to interact with it:
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "Panasonic Aquarea (aioaquarea)",
+  "content_in_root": true,
+  "render_readme": true,
+  "hide_default_branch": false
+}


### PR DESCRIPTION
Fixes HACS repo validation error by adding a minimal hacs.json. Also clarifies in the README that this is a Python library (not a HACS custom component) and directs users to the correct HA integration repo for HACS installation.

Closes #56