### PR TITLE
Add water pressure field and synthesize zone for monoblocks (#69, #73)

### DIFF
--- a/aioaquarea/data.py
+++ b/aioaquarea/data.py
@@ -311,6 +311,8 @@ class DeviceStatus:
     ----------
     special_status : SpecialStatus  | None
         Current special status of the device. As of now it only supports one value at a time.
+    water_pressure : float | None
+        Water pressure in bar (L-series models only).
     """
 
     long_id: str
@@ -329,6 +331,7 @@ class DeviceStatus:
     holiday_timer: HolidayTimer
     powerful_time: PowerfulTime
     special_status: SpecialStatus | None
+    water_pressure: float | None = None
 
 
 @dataclass
@@ -552,9 +555,24 @@ class Device(ABC):
         self.__build_zones__(info.zones)  # Use info.zones directly
 
     def __build_zones__(self, zones_info: list[DeviceZoneInfo]) -> None:
+        if not zones_info:
+            default_zone = DeviceZoneInfo(
+                zone_id=1,
+                name="Zone 1",
+                type="Room",
+                cool_mode=False,
+                zone_sensor=ZoneSensor.INTERNAL,
+                heat_sensor=SensorMode.DIRECT,
+                cool_sensor=None,
+            )
+            zone_status = next(
+                (z for z in self._status.zones if z.zone_id == 1), None
+            )
+            self._zones[1] = DeviceZone(default_zone, zone_status)
+            return
+
         for zone in zones_info:
             zone_id = zone.zone_id
-            # pylint: disable=cell-var-from-loop
             zone_status = next(
                 filter(lambda z: z.zone_id == zone_id, self._status.zones), None
             )
@@ -697,6 +715,11 @@ class Device(ABC):
     def special_status(self) -> SpecialStatus | None:
         """Specifies if the device is in a special status"""
         return self._status.special_status
+
+    @property
+    def water_pressure(self) -> float | None:
+        """Water pressure in bar (L-series models only)."""
+        return self._status.water_pressure
 
     def support_cooling(self, zone_id: int = 1) -> bool:
         """True if the device supports cooling in the given zone"""

--- a/aioaquarea/device_manager.py
+++ b/aioaquarea/device_manager.py
@@ -195,10 +195,18 @@ class DeviceManager:
         device = json_response.get("status")
         operation_mode_value = device.get("operationMode")
 
+        raw_water_pressure = device.get("waterPressure")
+        if raw_water_pressure is not None:
+            try:
+                raw_water_pressure = float(raw_water_pressure)
+            except (ValueError, TypeError):
+                raw_water_pressure = None
+
         device_status = DeviceStatus(
-            long_id=device_info.device_id,  # Use device_info.long_id here
+            long_id=device_info.device_id,
             operation_status=OperationStatus(device.get("specialStatus")),
             device_status=DeviceModeStatus(device.get("deiceStatus")),
+            water_pressure=raw_water_pressure,
             temperature_outdoor=device.get("outdoorNow"),
             operation_mode=(
                 ExtendedOperationMode.OFF


### PR DESCRIPTION
Two features in this PR:

**#69 - Water pressure monitoring:**
- New  field on  (float | None, default None)
- Parsed from  API response field
- Exposed as  property (in bar, L-series only)

**#73 - Monoblock zone synthesis:**
- When a device has zero zones in its config,  now synthesizes a single default Zone 1
- This allows WH-SDC0509 + WH-WDG models to create thermostat/climate entities
- The synthesized zone uses INTERNAL sensor and direct heat mode

Note: #70 (next scheduled timer action) depends on #3 weekly timer which is a separate PR. Will be addressed after #3 is merged.

Closes #69, #73