### PR TITLE
Add weekly timer with next scheduled action helper (#70)

### DIFF
--- a/aioaquarea/__init__.py
+++ b/aioaquarea/__init__.py
@@ -7,6 +7,8 @@ from typing import Tuple
 from .const import AquareaEnvironment
 from .core import AquareaClient as Client  # Import AquareaClient and alias it as Client
 from .data import (
+    DayOfWeek,
+    DaySchedule,
     Device,
     DeviceAction,
     DeviceDirection,
@@ -24,6 +26,8 @@ from .data import (
     SpecialStatus,
     Tank,
     UpdateOperationMode,
+    WeeklyTimerSettings,
+    WeeklyTimerSlot,
 )
 from .errors import (
     ApiError,
@@ -64,4 +68,8 @@ __all__: Tuple[str, ...] = (
     "PowerfulTime",
     "AquareaEnvironment",
     "SpecialStatus",
+    "DayOfWeek",
+    "DaySchedule",
+    "WeeklyTimerSettings",
+    "WeeklyTimerSlot",
 )

--- a/aioaquarea/core.py
+++ b/aioaquarea/core.py
@@ -26,6 +26,7 @@ from .data import (
     QuietMode,
     SpecialStatus,
     UpdateOperationMode,
+    WeeklyTimerSettings,
     ZoneTemperatureSetUpdate,
 )
 from .decorators import auth_required
@@ -33,6 +34,7 @@ from .device_control import AquareaDeviceControl
 from .device_manager import DeviceManager
 from .entities import DeviceImpl
 from .statistics import Consumption, DateType
+from .weekly_timer_manager import WeeklyTimerManager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -109,6 +111,9 @@ class AquareaClient:  # Renamed Client to AquareaClient
         self._consumption_manager = AquareaConsumptionManager(
             self._api_client, self._base_url, dt.timezone.utc
         )  # Pass timezone
+        self._weekly_timer_manager = WeeklyTimerManager(
+            self._api_client, self._base_url
+        )
         self._settings.username = username
         self._settings.password = password
         self._settings.access_token = self._api_client.access_token
@@ -373,6 +378,20 @@ class AquareaClient:  # Renamed Client to AquareaClient
         """Get device consumption."""
         return await self._consumption_manager.get_device_consumption(
             long_id, aggregation, date_input
+        )
+
+    async def get_device_weekly_timer(
+        self, device_id: str
+    ) -> WeeklyTimerSettings | None:
+        """Get the weekly timer schedule for a device."""
+        return await self._weekly_timer_manager.get_weekly_timer(device_id)
+
+    async def set_device_weekly_timer(
+        self, device_id: str, settings: WeeklyTimerSettings
+    ) -> None:
+        """Set the weekly timer schedule for a device."""
+        return await self._weekly_timer_manager.set_weekly_timer(
+            device_id, settings
         )
 
     async def close(self) -> None:

--- a/aioaquarea/data.py
+++ b/aioaquarea/data.py
@@ -233,6 +233,82 @@ class SpecialStatus(IntEnum):
     COMFORT = 2
 
 
+class DayOfWeek(IntEnum):
+    """Day of week for weekly timer"""
+
+    MONDAY = 1
+    TUESDAY = 2
+    WEDNESDAY = 3
+    THURSDAY = 4
+    FRIDAY = 5
+    SATURDAY = 6
+    SUNDAY = 7
+
+
+@dataclass
+class WeeklyTimerSlot:
+    """A single time slot in the weekly timer schedule"""
+
+    zone_id: int
+    start_hour: int
+    start_minute: int
+    end_hour: int
+    end_minute: int
+    heat_set: int | None = None
+    cool_set: int | None = None
+    enabled: bool = True
+
+
+@dataclass
+class DaySchedule:
+    """Schedule for a single day"""
+
+    day: DayOfWeek
+    slots: list[WeeklyTimerSlot]
+
+
+@dataclass
+class WeeklyTimerSettings:
+    """Weekly timer settings for a device"""
+
+    enabled: bool
+    schedule: list[DaySchedule]
+
+    def get_next_scheduled_action(self) -> tuple[DayOfWeek, WeeklyTimerSlot] | None:
+        """Find the next upcoming scheduled action based on current time.
+
+        :return: Tuple of (day, slot) for the next action, or None if no schedule
+        """
+        from datetime import datetime
+
+        now = datetime.now()
+        current_day = now.isoweekday()
+        current_minutes = now.hour * 60 + now.minute
+
+        for hours_offset in range(7 * 24 * 60):
+            check_minutes = (current_minutes + hours_offset) % (24 * 60)
+            check_day_value = ((current_day - 1 + (current_minutes + hours_offset) // (24 * 60))) % 7 + 1
+
+            try:
+                check_day = DayOfWeek(check_day_value)
+            except ValueError:
+                continue
+
+            for day_schedule in self.schedule:
+                if day_schedule.day != check_day:
+                    continue
+                for slot in day_schedule.slots:
+                    if not slot.enabled:
+                        continue
+                    slot_minutes = slot.start_hour * 60 + slot.start_minute
+                    if hours_offset == 0 and slot_minutes < current_minutes:
+                        continue
+                    if slot_minutes == check_minutes:
+                        return (check_day, slot)
+
+        return None
+
+
 @dataclass
 class TemperatureModifiers:
     heat: int | None
@@ -870,4 +946,15 @@ class Device(ABC):
         """Set the powerful time.
 
         :param powerful_time: Time to enable powerful mode
+        """
+
+    @abstractmethod
+    async def get_weekly_timer(self) -> "WeeklyTimerSettings | None":
+        """Get the weekly timer schedule."""
+
+    @abstractmethod
+    async def set_weekly_timer(self, settings: "WeeklyTimerSettings") -> None:
+        """Set the weekly timer schedule.
+
+        :param settings: The weekly timer settings to apply
         """

--- a/aioaquarea/entities.py
+++ b/aioaquarea/entities.py
@@ -22,6 +22,7 @@ from .data import (
     Tank,
     TankStatus,
     UpdateOperationMode,
+    WeeklyTimerSettings,
     ZoneTemperatureSetUpdate,
 )
 from .errors import DataNotAvailableError
@@ -375,6 +376,19 @@ class DeviceImpl(Device):
             await self._client.post_device_set_powerful_time(
                 self.long_id, powerful_time
             )
+
+    async def get_weekly_timer(self) -> WeeklyTimerSettings | None:
+        """Get the weekly timer schedule."""
+        return await self._client.get_device_weekly_timer(self._info.device_id)
+
+    async def set_weekly_timer(self, settings: WeeklyTimerSettings) -> None:
+        """Set the weekly timer schedule.
+
+        :param settings: The weekly timer settings to apply
+        """
+        await self._client.set_device_weekly_timer(
+            self._info.device_id, settings
+        )
 
     async def __set_special_status__(
         self,

--- a/aioaquarea/weekly_timer_manager.py
+++ b/aioaquarea/weekly_timer_manager.py
@@ -1,0 +1,136 @@
+import logging
+from typing import TYPE_CHECKING
+
+from .data import DayOfWeek, DaySchedule, WeeklyTimerSettings, WeeklyTimerSlot
+
+if TYPE_CHECKING:
+    from .api_client import AquareaAPIClient
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class WeeklyTimerManager:
+    """Handles weekly timer schedule retrieval and updates."""
+
+    def __init__(self, api_client: "AquareaAPIClient", base_url: str):
+        self._api_client = api_client
+        self._base_url = base_url
+
+    async def get_weekly_timer(self, device_id: str) -> WeeklyTimerSettings | None:
+        """Retrieve the weekly timer schedule for a device.
+        :param device_id: The device GUID
+        :return: WeeklyTimerSettings if available, None otherwise
+        """
+        payload = {
+            "apiName": "/remote/v1/api/weeklytimer",
+            "requestMethod": "GET",
+            "bodyParam": {"gwid": device_id},
+        }
+
+        response = await self._api_client.request(
+            "POST",
+            url="remote/v1/app/common/transfer",
+            json=payload,
+            throw_on_error=True,
+        )
+
+        data = await response.json()
+        return self._parse_weekly_timer_response(data, device_id)
+
+    async def set_weekly_timer(
+        self, device_id: str, settings: WeeklyTimerSettings
+    ) -> None:
+        """Update the weekly timer schedule for a device.
+        :param device_id: The device GUID
+        :param settings: The weekly timer settings to apply
+        """
+        schedule_data = []
+        for day_schedule in settings.schedule:
+            for slot in day_schedule.slots:
+                schedule_data.append(
+                    {
+                        "dayOfWeek": day_schedule.day.value,
+                        "zoneId": slot.zone_id,
+                        "startTime": f"{slot.start_hour:02d}:{slot.start_minute:02d}",
+                        "endTime": f"{slot.end_hour:02d}:{slot.end_minute:02d}",
+                        "heatSet": slot.heat_set,
+                        "coolSet": slot.cool_set,
+                        "enabled": slot.enabled,
+                    }
+                )
+
+        payload = {
+            "apiName": "/remote/v1/api/weeklytimer",
+            "requestMethod": "POST",
+            "bodyParam": {
+                "gwid": device_id,
+                "enabled": settings.enabled,
+                "schedule": schedule_data,
+            },
+        }
+
+        await self._api_client.request(
+            "POST",
+            url="remote/v1/app/common/transfer",
+            json=payload,
+            throw_on_error=True,
+        )
+
+    def _parse_weekly_timer_response(
+        self, data: dict, device_id: str
+    ) -> WeeklyTimerSettings | None:
+        if not data or "schedule" not in data:
+            _LOGGER.warning(
+                "No weekly timer data found for device %s. Response: %s",
+                device_id,
+                data,
+            )
+            return None
+
+        enabled = data.get("enabled", False)
+        raw_schedule = data.get("schedule", [])
+
+        day_map: dict[int, list[WeeklyTimerSlot]] = {}
+
+        for entry in raw_schedule:
+            day_value = entry.get("dayOfWeek")
+            if day_value is None:
+                continue
+
+            try:
+                day = DayOfWeek(day_value)
+            except ValueError:
+                _LOGGER.warning("Unknown day of week: %s", day_value)
+                continue
+
+            start_str = entry.get("startTime", "00:00")
+            end_str = entry.get("endTime", "00:00")
+
+            try:
+                start_hour, start_minute = map(int, start_str.split(":"))
+                end_hour, end_minute = map(int, end_str.split(":"))
+            except (ValueError, AttributeError):
+                _LOGGER.warning("Invalid time format: %s, %s", start_str, end_str)
+                continue
+
+            slot = WeeklyTimerSlot(
+                zone_id=entry.get("zoneId", 1),
+                start_hour=start_hour,
+                start_minute=start_minute,
+                end_hour=end_hour,
+                end_minute=end_minute,
+                heat_set=entry.get("heatSet"),
+                cool_set=entry.get("coolSet"),
+                enabled=entry.get("enabled", True),
+            )
+
+            if day.value not in day_map:
+                day_map[day.value] = []
+            day_map[day.value].append(slot)
+
+        schedule = [
+            DaySchedule(day=DayOfWeek(day_value), slots=slots)
+            for day_value, slots in sorted(day_map.items())
+        ]
+
+        return WeeklyTimerSettings(enabled=enabled, schedule=schedule)


### PR DESCRIPTION
Implements weekly timer schedule support with a convenience method to find the next upcoming action. New types: DayOfWeek, WeeklyTimerSlot, DaySchedule, WeeklyTimerSettings. The get_next_scheduled_action() method scans forward from current time across all days. Closes #70