### PR TITLE
Add a py.typed marker (PEP 561)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,6 @@ target-version = ["py39", "py310", "py311"]
 profile = "black"
 # will group `import x` and `from x import` of the same module.
 force_sort_within_sections = true
+
+[tool.setuptools.package-data]
+aioaquarea = ["py.typed"]


### PR DESCRIPTION
Closes #86.

`aioaquarea` is already annotated but ships no [PEP 561](https://peps.python.org/pep-0561/) marker, so mypy and pyright treat it as untyped for every downstream consumer — notably the Home Assistant Aquarea integration, which is adding a mypy CI job and currently has to blanket-ignore `aioaquarea.*`.

### Changes

- add an empty `aioaquarea/py.typed`
- `pyproject.toml`: declare it as package data so it ships in the wheel and the sdist

This asserts that the inline annotations are intended for downstream use. It does not claim the package is mypy-clean; `mypy` does not surface errors from inside installed third-party packages, so this is safe to ship as-is.

### Verification

```
$ python -m build
$ python -c "import zipfile,glob;print([n for n in zipfile.ZipFile(glob.glob('dist/*.whl')[0]).namelist() if 'py.typed' in n])"
['aioaquarea/py.typed']
$ python -c "import tarfile,glob;print([n for n in tarfile.open(glob.glob('dist/*.tar.gz')[0]).getnames() if 'py.typed' in n])"
['aioaquarea-1.0.7/aioaquarea/py.typed']
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
