### PR TITLE
feat: ship py.typed marker (PEP 561)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dependencies = [
 "Homepage" = "https://github.com/cjaliaga/aioaquarea"
 "Bug Tracker" = "https://github.com/cjaliaga/aioaquarea/issues"
 
+[tool.setuptools.package-data]
+aioaquarea = ["py.typed"]
+
 [tool.black]
 target-version = ["py39", "py310", "py311"]
 


### PR DESCRIPTION
## Summary

The package is substantially type-annotated but ships no `py.typed` marker, so PEP 561 type checkers (mypy, pyright) ignore the inline annotations (reported in #86).

## Changes
- Add `aioaquarea/py.typed`
- Declare it in `[tool.setuptools.package-data]` so it is included in built wheels

## Validation
- `py.typed` is an empty PEP 561 marker file (standard practice)
- setuptools>=61 backend reads `[tool.setuptools.package-data]` from pyproject.toml

Small, packaging-only change. Closes #86